### PR TITLE
Updated page title

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: IRIS IAM and SKA IAM Documentations
+site_name: IRIS IAM and SKA IAM Documentation Site
 nav:
   - Home: index.md
   - About:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: IRIS IAM and SKA IAM Documentation Site
+site_name: IRIS IAM and SKA IAM Documentation
 nav:
   - Home: index.md
   - About:


### PR DESCRIPTION
The more commonly used plural of Documentation is Documentation - removing the unneeded S from the page title.